### PR TITLE
feat/SK-13

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 *.css
 storybook-static
 stories
+src/**/*.test.tsx

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import Text from "./Text";
+
+describe("<Text> component", () => {
+  it("renders with default props", async () => {
+    const { baseElement } = render(<Text></Text>);
+    expect(baseElement.firstChild?.firstChild?.nodeName).toBe("SPAN");
+    expect(baseElement.firstChild?.firstChild?.textContent).toBe("");
+  });
+
+  describe("font weight props", () => {
+    const testCases = [
+      { prop: { black: "true" }, className: "font-black" },
+      { prop: { extrabold: "true" }, className: "font-extrabold" },
+      { prop: { bold: "true" }, className: "font-bold" },
+      { prop: { semibold: "true" }, className: "font-semibold" },
+      { prop: { regular: "true" }, className: "font-regular" },
+      { prop: { light: "true" }, className: "font-light" },
+      { prop: { extralight: "true" }, className: "font-extralight" },
+      { prop: { thin: "true" }, className: "font-thin" },
+    ];
+    it.each(testCases)(
+      "renders with classname $className when $prop is set",
+      ({ prop, className }) => {
+        const { baseElement } = render(
+          // @ts-ignore
+          <Text as="p" {...prop}>
+            font weight
+          </Text>
+        );
+        expect(baseElement.firstChild?.firstChild).toHaveClass(className);
+      }
+    );
+  });
+
+  describe("font style props", () => {
+    const testCases = [
+      { prop: { sans: "true" }, className: "font-sans" },
+      { prop: { mono: "true" }, className: "font-mono" },
+      { prop: { serif: "true" }, className: "font-serif" },
+    ];
+    it.each(testCases)(
+      "renders with classname $className when $prop is set",
+      ({ prop, className }) => {
+        const { baseElement } = render(
+          // @ts-ignore
+          <Text as="p" {...prop}>
+            font weight
+          </Text>
+        );
+        expect(baseElement.firstChild?.firstChild).toHaveClass(className);
+      }
+    );
+  });
+
+  describe("text size props", () => {
+    const testCases = [
+      { prop: { xs: "true" }, className: "text-xs" },
+      { prop: { sm: "true" }, className: "text-sm" },
+      { prop: { base: "true" }, className: "text-base" },
+      { prop: { lg: "true" }, className: "text-lg" },
+      { prop: { xl: "true" }, className: "text-xl" },
+      { prop: { xxl: "true" }, className: "text-2xl" },
+      { prop: { xxxl: "true" }, className: "text-3xl" },
+      { prop: { xxxxl: "true" }, className: "text-4xl" },
+      { prop: { xxxxxl: "true" }, className: "text-5xl" },
+    ];
+    it.each(testCases)(
+      "renders with classname $className when $prop is set",
+      ({ prop, className }) => {
+        const { baseElement } = render(
+          // @ts-ignore
+          <Text as="p" {...prop}>
+            font weight
+          </Text>
+        );
+        expect(baseElement.firstChild?.firstChild).toHaveClass(className);
+      }
+    );
+  });
+});

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode } from "react";
 import { PolymorphicComponentProps } from "../../utils/polymorphic";
 
 interface TextProps {
-  children: ReactNode;
+  children?: ReactNode;
   tw?: string;
 }
 
@@ -64,7 +64,7 @@ const Text = <T extends React.ElementType = "span">({
       {...props}
       className={`${className} ${tw} ${props.className ?? ""}`.trim()}
     >
-      {props.children}
+      {props.children ?? ""}
     </Element>
   );
 };


### PR DESCRIPTION
[Notion](https://www.notion.so/Component-Text-0e3c5098be084028be3d770b6d291dee)
As a consumer developer I should be able to use a generic container Text component. The Text component should feature the following:

- [x]  Fully polyphormic via an ‘as’ props that accepts any valid HTML element
- [x]  It should extend whatever props the `as` HMTL has, this should be done in a type-safe manner, for example if the `as` prop is set to `label`; `htmlFor` should be a valid prop, but not `href`, default `as` prop to `span`
- [x]  Renders text or other elements as its children

Have the following [mutually exclusive boolean props](https://www.notion.so/Component-Props-f5dd93fec2c047f89092f7704c83e747):

- [x]  `black`, `extrabold`, `bold`, `semibold`, `regular`, `light`, `extralight`, `thin` (font-weight)
- [x]  `sans`, `serif`, `mono` (font-style)
- [x]  `xs`, `sm`,  `base`, `lg`, `xl`, `xxl`, `xxxl`, `xxxxl`, `xxxxxl` (font-size)

Common props:

- [x]  `tw`, `className`

Documentation and testing:

- [x]  Meaningful tests
- [x]  Story example entry